### PR TITLE
docs: update precompiled binaries section

### DIFF
--- a/source/AddFuncts/entertainment.rst
+++ b/source/AddFuncts/entertainment.rst
@@ -1,7 +1,7 @@
 Hue Entertainment
 =================
 
-The DTLS server used by Hue Entertainment is a 3rd party service build in C. Precompiled binaries are provided for X86_64 and armv7 (Raspberry Pi 2 & 3) architectures. For any other architecture the service must be compiled from source. It would be good if the compiled executable could be uploaded with a pull request for other architectures like armv6 (Raspberry Pi 1)
+The DTLS server used by Hue Entertainment is a 3rd party service build in C. Precompiled binaries are provided for x86_64, i686 (x86), aarch64, arm64 (e.g. Rock Pi) and arm (e.g. Raspberry Pi) architectures. For any other architecture the service must be compiled from source. It would be good if the compiled executable could be uploaded with a pull request for other architectures.
 
 Compilation Commands
 --------------------


### PR DESCRIPTION
...to match what binaries are actually available as of now.
Latest addition was via https://github.com/diyhue/diyHue/pull/80

---

The main question: Are there any known architecture that are missing?