### PR TITLE
Fix typo in the Get-Started section in the Docs

### DIFF
--- a/source/getting_started.rst
+++ b/source/getting_started.rst
@@ -135,7 +135,7 @@ Run the following command to update::
 
     cd /tmp && wget --no-check-certificate https://raw.githubusercontent.com/diyhue/diyHue/master/BridgeEmulator/update_openwrt.sh && sh update_openwrt.sh
 
-At the end of the system it restarts automatically.
+After the update has finished, the system will restart automatically.
 
 Demo
 ~~~~


### PR DESCRIPTION
Just a small typo fix in the docs, to make it clear that the system will restart automatically after the update.