### PR TITLE
Correct list of advantages of directly connecting Tradfri devices.

### DIFF
--- a/source/lights/ikea.rst
+++ b/source/lights/ikea.rst
@@ -4,7 +4,6 @@ IKEA Tradfri
 There are two ways to interact with IKEA Tradfri devices, one method is to use the Tradfri Gateway and you will be able to control just the lights.
 The second method is to use the Raspbee module that offers the flowing advantages:
 
-* The ability to setup multiple sensors and switched in same room, while the Tradfri application only gives the possibility to configure just one switch or sensor per group (room).
 * Add custom rules for sensors and switches
 * Tradfri Motion Sensors are emulated as Hue Motion Sensor giving the possibility to choose different scenes based on the time (ex: max brightness between 08:00 - 23:00 and Nightlight scene between 23:00 and 08:00) Also the light will be dimmed for 30 seconds before being turned off and you can configure from Hue application how much time the light will stay on after motion was triggered.
 * The Tradfri Remote can be emulated as a Hue Dimmer Switch or Hue Tap Switch that can apply color scenes.


### PR DESCRIPTION
It is possible to pair and use multiple control devices for one group of lights. Next control devices has to be paired not directly with gateway, but by pressing pairing buttons on first and next control devices. Instructions in Tradfri application are incorrect, but this method works and both control devices appears on list of devices and works correctly.

---
labels: PR
---

* Description of changes
Please write a short description of the changes or addtions you have made.
